### PR TITLE
Path to bower_components may now be overridden with paths.bowerDirectory config

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ var gulpBowerSrc = function(config) {
 
     var bowerJsonPath = config.paths.bowerJson || "./bower.json";
     var bowerrcPath = config.paths.bowerrc || "./.bowerrc";
-    var bowerDirectory = "./bower_components";
+    var bowerDirectory = config.paths.bowerDirectory || "./bower_components";
 
     if(fs.existsSync(bowerrcPath)){
         bowerDirectory = path.resolve("./", (JSON.parse(fs.readFileSync(bowerrcPath))).directory);


### PR DESCRIPTION
We have a project with multiple submodules that are all web applications, each with their own `package.json` and `bower.json`.
In order to simplify stuff we merged them all into one `package.json` and `bower.json` and moved them up to the root folder of the project. This now leads to one single `node_modules` and `bower_components` folder.
This works fine up and until bower tries to build a distro, making use of `gulp-bower-src` in the process. Since Gulp is triggered from each one of the submodule paths (we still have separate `Gulpfile.js` files) `gulp-bower-src` keeps looking for the `bower_components` folder in the wrong path - in that of the submodule, instead of in the root folder.

This additional configuration option that I added makes it possible to override that behaviour, so `gulp-bower-src` is capable of handling a `bower_components` path wherever it is, and not just as a subfolder of the current path.

Yes, one could also solve this with a `.bowerrc` in each one of the submodules, so this is just a convenience method in case you don't want/can't/whatever have `.bowerrc` files like this in there:

```
{
    "directory": "../bower_components"
}
```
